### PR TITLE
Update trim-galore to version 0.4.4

### DIFF
--- a/trim-galore.rb
+++ b/trim-galore.rb
@@ -4,8 +4,8 @@ class TrimGalore < Formula
   # doi ""
   # tag "bioinformatics"
 
-  url "http://www.bioinformatics.babraham.ac.uk/projects/trim_galore/trim_galore_v0.4.1.zip"
-  sha256 "7e7609c68c54032e985eedf36d3b810f39e5bd3d1003a3686f2a34f532ae5d3d"
+  url "https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/trim_galore_v0.4.4.zip"
+  sha256 "ccd7eecc73327da29230f3e7c7311a4e21b2cfe7282be18fa059ba900fc33116"
 
   depends_on "IPC::Open3" => :perl
   depends_on "cutadapt"


### PR DESCRIPTION
This is quite an important update since 0.4.1 has a [fatal bug](https://www.biostars.org/p/204664/#246455) on macOS which is subsequently fixed.

Trying to install this formula as-is fails, by the way, because Homebrew finds a conflict between `homebrew/science/cutadapt` and `tseemann/bioinformatics-linux/cutadapt`. This would require either removing the (redundant) `cutadapt` formula, or fixing the dependency in `trim-galore`. I haven’t done so in this PR since that’s unrelated.